### PR TITLE
support multiple different ron file types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 target
 Cargo.lock
 *.bk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "derive"]
 
 [package]
 name = "ron_asset_manager"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Lorenz Mielke"]
 description = "A dead simple crate to manage Ron based assets which depend on other assets."

--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ pub struct Weapon{
 // this steps also initializes the asset for bevy.
 fn build(&self, app: &mut App) {
     app.add_plugins(RonAssetPlugin::<Wizard>::default());
+    
+    // or specify custom file format (useful for multiple asset types)
+    // app.add_plugins(RonAssetPlugin::<Wizard>::create("wizzard.ron"));
+    // app.add_plugins(RonAssetPlugin::<Spell>::create("spell.ron"));
 }
 
 // that's all, time to use it
 fn spawn_wizard(mut cmd: Commands, server: Res<AssetServer>){
-    let wizard_handle: Handle<Wizard> = server.load("enemies/gandalf.ron")
+    let wizard_handle: Handle<Wizard> = server.load("enemies/gandalf.ron");
 
     cmd.spawn((
         WizardSpawner(wizard_handle),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,23 +61,35 @@ pub enum RonAssetError {
 }
 
 pub struct RonAssetPlugin<T: Asset> {
+    ext: String,
     _m: std::marker::PhantomData<T>,
 }
 
 impl<T: Asset> Default for RonAssetPlugin<T> {
     fn default() -> Self {
         Self {
+            ext: String::from("ron"),
+            _m: Default::default(),
+        }
+    }
+}
+
+impl<T: Asset> RonAssetPlugin<T> {
+    pub fn create(ext: &str) -> Self {
+        Self {
+            ext: String::from(ext),
             _m: Default::default(),
         }
     }
 }
 
 struct RonAssetLoader<T: Asset> {
+    ext: [&'static str; 1],
     _m: std::marker::PhantomData<T>,
 }
-impl<T: Asset> Default for RonAssetLoader<T> {
-    fn default() -> Self {
-        Self { _m: default() }
+impl<T: Asset> RonAssetLoader<T> {
+    fn create(ext: &'static str) -> Self {
+        Self { ext: [ext], _m: default() }
     }
 }
 
@@ -105,7 +117,7 @@ where
     }
 
     fn extensions(&self) -> &[&str] {
-        &["ron"]
+        &self.ext
     }
 }
 
@@ -120,7 +132,7 @@ where
 {
     fn build(&self, app: &mut App) {
         app.init_asset::<T>();
-        app.register_asset_loader(RonAssetLoader::<T>::default());
+        app.register_asset_loader(RonAssetLoader::<T>::create(self.ext.clone().leak()));
     }
 }
 


### PR DESCRIPTION
Hello, this is simple PR, that allow to use custom file format and multiple different asset files types.

Now plugin can be used in two different ways:
```rust
// there are the same
app.add_plugins(RonAssetPlugin::<Wizard>::default());
app.add_plugins(RonAssetPlugin::<Wizard>::create("ron"));

// but we can register multiple different types
app.add_plugins(RonAssetPlugin::<Wizard>::create("wizzard.ron"));
app.add_plugins(RonAssetPlugin::<Spell>::create("spell.ron"));
```