### PR TITLE
add support for option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "derive"]
 
 [package]
 name = "ron_asset_manager"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Lorenz Mielke"]
 description = "A dead simple crate to manage Ron based assets which depend on other assets."

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This crates provides the `RonAsset` derive macro, `RonAssetPlugin` and the `Shan
 The idea is to mark asset dependencies via attribute.
 
 Any field, implementing the `RonAsset` trait can be nested and will automatic load.
-There are defaults for `Vec` and `HashMap`. You can also implement your own, if you need to.
+There are defaults for `Option`, `Vec` and `HashMap`. You can also implement your own, if you need to.
 
 `cargo run --example simple`
 
@@ -55,6 +55,8 @@ pub struct Weapon{
     pub cooldown: f32,
     #[asset]
     pub sprite: Shandle<Image>,
+    #[asset]
+    pub birth_effect: Option<Shandle<Image>>,
 }
 
 // add the provided plugin for your asset struct.
@@ -100,6 +102,7 @@ _gandalf.ron_:
         damage: 99,
         cooldown: 1,
         sprite: "staff.png"
-    )
+    ),
+    birth_effect: Some("fx/common_death.fx.ron")
 )
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,19 @@ impl<T: Asset> RonAsset for Shandle<T> {
     }
 }
 
+impl<R> RonAsset for Option<R>
+where
+    R: RonAsset,
+{
+    fn load_assets(&mut self, context: &mut LoadContext) {
+        if self.is_none() {
+            return;
+        }
+
+        self.as_mut().unwrap().load_assets(context);
+    }
+}
+
 impl<R> RonAsset for Vec<R>
 where
     R: RonAsset,


### PR DESCRIPTION
Hi, another PR for adding `Option<T>` to the list of commonly supported traits of RonAsset.

example:
```
(
  birth_effect: Some("fx/common_death.fx.ron"),
  death_effect: None,
)
```