### PR TITLE
Support for bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "derive"]
 
 [package]
 name = "ron_asset_manager"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Lorenz Mielke"]
 description = "A dead simple crate to manage Ron based assets which depend on other assets."
@@ -13,11 +13,11 @@ readme = "README.md"
 repository = "https://github.com/Lommix/ron_asset_manager.git"
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = ["bevy_asset"] }
-ron_asset_derive = "0.5"
-ron = "0.8.1"
-serde = { version = "1.0.214", features = ["derive"] }
-thiserror = "1.0.66"
+bevy = { version = "0.18", default-features = false, features = ["bevy_asset"] }
+ron_asset_derive = { path = "derive", version = "0.6" }
+ron = "0"
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
 
 [dev-dependencies]
-bevy = { version = "0.17", default-features = true, features = ["reflect_auto_register_static"] }
+bevy = { version = "0.18", default-features = true, features = ["reflect_auto_register_static"] }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ advantage!
 #### **Any asset, that can be loaded from an asset path is supported!**
 
 | bevy | ron asset manager |
-| :--- | :---------------- |
+|:-----|:------------------|
+| 0.18 | 0.8               |
 | 0.17 | 0.7               |
 | 0.16 | 0.6               |
 | 0.15 | 0.5               |
@@ -63,7 +64,7 @@ pub struct Weapon{
 
 // add the provided plugin for your asset struct.
 // this steps also initializes the asset for bevy.
-fn build(&self, app: &mut App) {
+fn build(app: &mut App) {
     app.add_plugins(RonAssetPlugin::<Wizard>::default());
 
     // or specify custom file format (useful for multiple asset types)

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ron_asset_derive"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Lorenz Mielke"]
 description = "a proc macro to help with asset dependencies"
@@ -12,8 +12,5 @@ repository = "https://github.com/Lommix/ron_asset_manager.git"
 proc-macro = true
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = ["bevy_asset"] }
-serde = { version = "1.0.214", features = ["derive"] }
-proc-macro2 = "1.0.89"
-quote = "1.0.37"
-syn = "2.0.86"
+quote = "1"
+syn = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ impl<T: Asset> RonAssetPlugin<T> {
     }
 }
 
+#[derive(TypePath)]
 struct RonAssetLoader<T: Asset> {
     ext: [&'static str; 1],
     _m: std::marker::PhantomData<T>,
@@ -151,10 +152,10 @@ where
 }
 
 /// `Shandle<T>` is a thin wrapper around `Handle<T>`
-/// that implements the `Seriliaze` & `Deserialze` traits.
+/// that implements the `Serialize` & `Deserialize` traits.
 ///
 /// Deriving `RonAsset` ensures, that each Shandle with a valid
-/// asset path is loaded by the asset server aswell.
+/// asset path is loaded by the asset server as well.
 #[derive(Debug, Default, Clone)]
 pub struct Shandle<T: Asset> {
     pub handle: Handle<T>,
@@ -195,16 +196,16 @@ impl<'de, T: Asset> serde::Deserialize<'de> for Shandle<T> {
     where
         D: serde::Deserializer<'de>,
     {
-        let path = deserializer.deserialize_string(AssetPathVistor)?;
-        return Ok(Shandle {
+        let path = deserializer.deserialize_string(AssetPathVisitor)?;
+        Ok(Shandle {
             handle: Handle::default(),
             path,
-        });
+        })
     }
 }
 
-struct AssetPathVistor;
-impl<'de> Visitor<'de> for AssetPathVistor {
+struct AssetPathVisitor;
+impl<'de> Visitor<'de> for AssetPathVisitor {
     type Value = String;
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter.write_str("provided handle value is not a path string")


### PR DESCRIPTION
Update dependencies to Bevy 0.18.

Additional changes included:
- Local path dependency for the derive macro
- Cleanup of unused dependencies
- Less restrictive dependency versions
- Typo fix

Thanks for your review!
