### PR TITLE
update dependencies to Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "derive"]
 
 [package]
 name = "ron_asset_manager"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Lorenz Mielke"]
 description = "A dead simple crate to manage Ron based assets which depend on other assets."
@@ -13,11 +13,11 @@ readme = "README.md"
 repository = "https://github.com/Lommix/ron_asset_manager.git"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.19", default-features = false, features = ["bevy_asset"] }
 ron_asset_derive = { path = "derive", version = "0.6" }
 ron = "0"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = true, features = ["reflect_auto_register_static"] }
+bevy = { version = "0.19", default-features = true, features = ["reflect_auto_register_static"] }


### PR DESCRIPTION
Bump `bevy` from 0.18 to 0.19 (in both dependencies and dev-dependencies) and the crate version from 0.8.0 to 0.9.0.